### PR TITLE
Adicionar zeros à esquerda do CRC16 quando necessário

### DIFF
--- a/funcoes_pix.php
+++ b/funcoes_pix.php
@@ -91,6 +91,8 @@ function crcChecksum($str) {
    $hex = $crc & 0xFFFF;
    $hex = dechex($hex);
    $hex = strtoupper($hex);
+   $hex = str_pad($hex, 4, '0', STR_PAD_LEFT);
+
    return $hex;
 }
 


### PR DESCRIPTION
Oi, Renato! Tudo bem?

Primeiro, obrigado pelo código!

Encontrei um bug na geração do CRC16, quando o resultado dele é numérico iniciando em zero a função considera um número e remove o zero. Então antes de retornar o resultado fiz forçar o tamanho de 4 caracteres adicionando zeros à esquerda quando necessário.