### PR TITLE
bugfix/cannotRedeclareCharCodeAt: fix FATAL ERROR Cannot redeclare charCodeAt() ( previously declared in funcoes_pix.php:110 ) in funcoes_pix.php:110

### DIFF
--- a/funcoes_pix.php
+++ b/funcoes_pix.php
@@ -101,6 +101,10 @@ function c2($input){
     return str_pad($input, 2, "0", STR_PAD_LEFT);
 }
 
+// The PHP version of the JS str.charCodeAt(i)
+function charCodeAt($str, $i) {
+   return ord(substr($str, $i, 1));
+}
 
 function crcChecksum($str) {
    /*
@@ -109,11 +113,6 @@ function crcChecksum($str) {
    # Autor: evilReiko (https://stackoverflow.com/users/134824/evilreiko)
    # Postada originalmente em: https://stackoverflow.com/questions/30035582/how-to-calculate-crc16-ccitt-in-php-hex
    */
-  // The PHP version of the JS str.charCodeAt(i)
-   function charCodeAt($str, $i) {
-      return ord(substr($str, $i, 1));
-   }
-
    $crc = 0xFFFF;
    $strlen = strlen($str);
    for($c = 0; $c < $strlen; $c++) {


### PR DESCRIPTION
bugfix/cannotRedeclareCharCodeAt: fix FATAL ERROR Cannot redeclare charCodeAt() ( previously declared in funcoes_pix.php:110 ) in funcoes_pix.php:110